### PR TITLE
Support for UTF8 charset

### DIFF
--- a/examples/app/app/build.gradle
+++ b/examples/app/app/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.jakewharton:butterknife:7.0.1'
     compile 'com.nononsenseapps:filepicker:2.4.2'
-    compile 'net.gotev:uploadservice:2.0'
+    //compile 'net.gotev:uploadservice:2.0'
     //comment the previous line and uncomment the next line for development (it uses the local lib)
-    //compile project(':uploadservice')
+    compile project(':uploadservice')
 }

--- a/examples/app/app/src/main/java/net/gotev/uploadservicedemo/MainActivity.java
+++ b/examples/app/app/src/main/java/net/gotev/uploadservicedemo/MainActivity.java
@@ -64,6 +64,7 @@ public class MainActivity extends AppCompatActivity {
     @Bind(R.id.autoDeleteUploadedFiles) CheckBox autoDeleteUploadedFiles;
     @Bind(R.id.autoClearOnSuccess) CheckBox autoClearOnSuccess;
     @Bind(R.id.fixedLengthStreamingMode) CheckBox fixedLengthStreamingMode;
+    @Bind(R.id.useUtf8) CheckBox useUtf8;
 
     private Map<String, UploadProgressViewHolder> uploadProgressHolders = new HashMap<>();
 
@@ -178,14 +179,19 @@ public class MainActivity extends AppCompatActivity {
             try {
                 final String filename = getFilename(fileToUploadPath);
 
-                String uploadID = new MultipartUploadRequest(this, serverUrlString)
+                MultipartUploadRequest req = new MultipartUploadRequest(this, serverUrlString)
                         .addFileToUpload(fileToUploadPath, paramNameString)
                         .setNotificationConfig(getNotificationConfig(filename))
                         .setCustomUserAgent(USER_AGENT)
                         .setAutoDeleteFilesAfterSuccessfulUpload(autoDeleteUploadedFiles.isChecked())
                         .setUsesFixedLengthStreamingMode(fixedLengthStreamingMode.isChecked())
-                        .setMaxRetries(2)
-                        .startUpload();
+                        .setMaxRetries(2);
+
+                if (useUtf8.isChecked()) {
+                    req.setUtf8Charset();
+                }
+
+                String uploadID = req.startUpload();
 
                 addUploadToList(uploadID,filename);
 

--- a/examples/app/app/src/main/res/layout/activity_main.xml
+++ b/examples/app/app/src/main/res/layout/activity_main.xml
@@ -83,6 +83,14 @@
         <CheckBox
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:text="@string/use_utf8_charset"
+            android:id="@+id/useUtf8"
+            android:layout_gravity="start"
+            android:checked="true" />
+
+        <CheckBox
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:text="@string/fixed_length_streaming_mode"
             android:id="@+id/fixedLengthStreamingMode"
             android:layout_gravity="start"

--- a/examples/app/app/src/main/res/values/strings.xml
+++ b/examples/app/app/src/main/res/values/strings.xml
@@ -23,5 +23,6 @@
     <string name="options">Options</string>
     <string name="auto_clear_on_success">Auto clear on success</string>
     <string name="fixed_length_streaming_mode">Fixed length streaming mode</string>
+    <string name="use_utf8_charset">Use UTF-8 charset (un-check to use US-ASCII)</string>
 
 </resources>

--- a/uploadservice/src/main/java/net/gotev/uploadservice/MultipartUploadRequest.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/MultipartUploadRequest.java
@@ -1,6 +1,7 @@
 package net.gotev.uploadservice;
 
 import android.content.Context;
+import android.content.Intent;
 
 import java.io.FileNotFoundException;
 import java.net.MalformedURLException;
@@ -16,6 +17,8 @@ import java.util.List;
  *
  */
 public class MultipartUploadRequest extends HttpUploadRequest {
+
+    private boolean isUtf8Charset = false;
 
     /**
      * Creates a new multipart upload request.
@@ -44,6 +47,12 @@ public class MultipartUploadRequest extends HttpUploadRequest {
      */
     public MultipartUploadRequest(final Context context, final String serverUrl) {
         this(context, null, serverUrl);
+    }
+
+    @Override
+    protected void initializeIntent(Intent intent) {
+        super.initializeIntent(intent);
+        intent.putExtra(MultipartUploadTask.PARAM_UTF8_CHARSET, isUtf8Charset);
     }
 
     @Override
@@ -174,6 +183,16 @@ public class MultipartUploadRequest extends HttpUploadRequest {
     @Override
     public MultipartUploadRequest setUsesFixedLengthStreamingMode(boolean fixedLength) {
         super.setUsesFixedLengthStreamingMode(fixedLength);
+        return this;
+    }
+
+    /**
+     * Sets the charset for this multipart request to UTF-8. If not set, the standard US-ASCII
+     * charset will be used.
+     * @return request instance
+     */
+    public MultipartUploadRequest setUtf8Charset() {
+        isUtf8Charset = true;
         return this;
     }
 }

--- a/uploadservice/src/main/java/net/gotev/uploadservice/NameValue.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/NameValue.java
@@ -4,6 +4,7 @@ import android.os.Parcel;
 import android.os.Parcelable;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 
 /**
  * Represents a request parameter.
@@ -18,6 +19,9 @@ public final class NameValue implements Parcelable {
     private final String name;
     private final String value;
 
+    private final Charset US_ASCII = Charset.forName("US-ASCII");
+    private final Charset UTF8 = Charset.forName("UTF-8");
+
     public NameValue(final String name, final String value) {
         this.name = name;
         this.value = value;
@@ -31,9 +35,9 @@ public final class NameValue implements Parcelable {
         return value;
     }
 
-    public byte[] getMultipartBytes() throws UnsupportedEncodingException {
+    public byte[] getMultipartBytes(boolean isUtf8) throws UnsupportedEncodingException {
         return ("Content-Disposition: form-data; name=\"" + name + "\""
-                + NEW_LINE + NEW_LINE + value).getBytes("UTF-8");
+                + NEW_LINE + NEW_LINE + value).getBytes(isUtf8 ? UTF8 : US_ASCII);
     }
 
     @Override

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadFile.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadFile.java
@@ -9,6 +9,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 
 /**
  * Represents a file to upload.
@@ -25,6 +26,9 @@ public class UploadFile implements Parcelable {
     protected final String paramName;
     protected final String fileName;
     protected String contentType;
+
+    private final Charset US_ASCII = Charset.forName("US-ASCII");
+    private final Charset UTF8 = Charset.forName("UTF-8");
 
     /**
      * Creates a new UploadFile.
@@ -98,10 +102,11 @@ public class UploadFile implements Parcelable {
 
     /**
      * Gets the HTTP/Multipart header for this file.
+     * @param isUtf8 true to get the multipart header in UTF-8 charset, false to use US-ASCII
      * @return multipart header bytes
-     * @throws UnsupportedEncodingException if the device does not support US-ASCII encoding
+     * @throws UnsupportedEncodingException if the device does not support the selected encoding
      */
-    public byte[] getMultipartHeader() throws UnsupportedEncodingException {
+    public byte[] getMultipartHeader(boolean isUtf8) throws UnsupportedEncodingException {
         StringBuilder builder = new StringBuilder();
 
         builder.append("Content-Disposition: form-data; name=\"")
@@ -110,7 +115,7 @@ public class UploadFile implements Parcelable {
 
         builder.append("Content-Type: ").append(contentType).append(NEW_LINE).append(NEW_LINE);
 
-        return builder.toString().getBytes("US-ASCII");
+        return builder.toString().getBytes(isUtf8 ? UTF8 : US_ASCII);
     }
 
     /**
@@ -119,11 +124,13 @@ public class UploadFile implements Parcelable {
      * and some bytes needed for the multipart headers
      *
      * @param boundaryBytesLength length in bytes of the multipart boundary
+     * @param isUtf8 true to get the multipart header in UTF-8 charset, false to use US-ASCII
      * @return total number of bytes needed by this file in the HTTP/Multipart request
-     * @throws UnsupportedEncodingException if the device does not support US-ASCII encoding
+     * @throws UnsupportedEncodingException if the device does not support the selected encoding
      */
-    public long getTotalMultipartBytes(long boundaryBytesLength) throws UnsupportedEncodingException {
-        return boundaryBytesLength + getMultipartHeader().length + file.length();
+    public long getTotalMultipartBytes(long boundaryBytesLength, boolean isUtf8)
+            throws UnsupportedEncodingException {
+        return boundaryBytesLength + getMultipartHeader(isUtf8).length + file.length();
     }
 
     private String autoDetectMimeType() {


### PR DESCRIPTION
This implements the behaviour requested in #82 with some differences. 
When using US ASCII charset, all the unrecognized chars will be represented as `?`.
To switch between the default US ASCII encoding and UTF 8, it's sufficient to call `setUtf8Charset` method on the multipart upload request object.

#### UTF 8 Encoding

Multipart Request dump (shown in UTF-8):
```
POST /upload/multipart HTTP/1.1
Connection: close
Content-Type: multipart/form-data; boundary=-------AndroidUploadService1454843592675
User-Agent: UploadServiceDemo/2.0
Content-Length: 347
Host: 10.0.2.2:3000
Accept-Encoding: gzip


---------AndroidUploadService1454843592675
Content-Disposition: form-data; name="param1"

тест
---------AndroidUploadService1454843592675
Content-Disposition: form-data; name="file1"; filename="тест файл.txt"
Content-Type: text/plain

sometext
нещо на кирилица

---------AndroidUploadService1454843592675--
```

node.js server output:
```
HTTP/Multipart Upload Request from: ::ffff:127.0.0.1

Received headers
----------------
connection: close
content-type: multipart/form-data; boundary=-------AndroidUploadService1454843592675
user-agent: UploadServiceDemo/2.0
content-length: 347
host: 10.0.2.2:3000
accept-encoding: gzip

Started file upload
  parameter name: file1
  file name: тест файл.txt
  mime type: text/plain
Completed file upload
  parameter name: file1
  file name: тест файл.txt
  mime type: text/plain
  in: /Users/alex/workspace/android-upload-service/examples/server-nodejs/uploads/тест файл.txt

Received Parameters
-------------------
param1: тест
```

#### US ASCII Encoding

Multipart Request dump (shown in UTF-8):
```
POST /upload/multipart HTTP/1.1
Connection: close
Content-Type: multipart/form-data; boundary=-------AndroidUploadService1454843673666
User-Agent: UploadServiceDemo/2.0
Content-Length: 334
Host: 10.0.2.2:3000
Accept-Encoding: gzip


---------AndroidUploadService1454843673666
Content-Disposition: form-data; name="param1"

????
---------AndroidUploadService1454843673666
Content-Disposition: form-data; name="file1"; filename="???? ?????.txt"
Content-Type: text/plain

sometext
нещо на кирилица

---------AndroidUploadService1454843673666--
```

node.js server output:
```
HTTP/Multipart Upload Request from: ::ffff:127.0.0.1

Received headers
----------------
connection: close
content-type: multipart/form-data; boundary=-------AndroidUploadService1454843673666
user-agent: UploadServiceDemo/2.0
content-length: 334
host: 10.0.2.2:3000
accept-encoding: gzip

Started file upload
  parameter name: file1
  file name: ???? ?????.txt
  mime type: text/plain
Completed file upload
  parameter name: file1
  file name: ???? ?????.txt
  mime type: text/plain
  in: /Users/alex/workspace/android-upload-service/examples/server-nodejs/uploads/???? ?????.txt

Received Parameters
-------------------
param1: ????
```


