### PR TITLE
Added redirect URL support after upload

### DIFF
--- a/uploadservice-okhttp/src/main/java/net/gotev/uploadservice/okhttp/OkHttpStackConnection.java
+++ b/uploadservice-okhttp/src/main/java/net/gotev/uploadservice/okhttp/OkHttpStackConnection.java
@@ -115,6 +115,11 @@ public class OkHttpStackConnection implements HttpConnection {
     }
 
     @Override
+    public String getServerResponseHeaderValue(String headerKey) throws IOException {
+        return mConnection.getHeaderField(headerKey);
+    }
+
+    @Override
     public void close() {
         Logger.debug(getClass().getSimpleName(), "closing connection");
 

--- a/uploadservice/src/main/java/net/gotev/uploadservice/BroadcastData.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/BroadcastData.java
@@ -26,6 +26,7 @@ class BroadcastData implements Parcelable {
     private long totalBytes;
     private int responseCode;
     private byte[] responseBody = new byte[0];
+    private String redirectLocation;
 
     public BroadcastData() {
 
@@ -60,6 +61,7 @@ class BroadcastData implements Parcelable {
         parcel.writeLong(uploadedBytes);
         parcel.writeLong(totalBytes);
         parcel.writeInt(responseCode);
+        parcel.writeString(redirectLocation);
 
         parcel.writeInt(responseBody.length);
         parcel.writeByteArray(responseBody);
@@ -72,6 +74,7 @@ class BroadcastData implements Parcelable {
         uploadedBytes = in.readLong();
         totalBytes = in.readLong();
         responseCode = in.readInt();
+        redirectLocation = in.readString();
 
         responseBody = new byte[in.readInt()];
         in.readByteArray(responseBody);
@@ -146,6 +149,15 @@ class BroadcastData implements Parcelable {
 
     public BroadcastData setResponseBody(byte[] responseBody) {
         this.responseBody = responseBody;
+        return this;
+    }
+
+    public String getRedirectLocation() {
+        return redirectLocation;
+    }
+
+    public BroadcastData setRedirectLocation(String redirectLocation) {
+        this.redirectLocation = redirectLocation;
         return this;
     }
 }

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadServiceBroadcastReceiver.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadServiceBroadcastReceiver.java
@@ -34,6 +34,8 @@ public class UploadServiceBroadcastReceiver extends BroadcastReceiver {
 
             case COMPLETED:
                 onCompleted(data.getId(), data.getResponseCode(), data.getResponseBody());
+                onCompleted(data.getId(), data.getResponseCode(),
+                        data.getResponseBody(), data.getRedirectLocation());
                 break;
 
             case IN_PROGRESS:
@@ -119,6 +121,23 @@ public class UploadServiceBroadcastReceiver extends BroadcastReceiver {
      */
     public void onCompleted(final String uploadId, final int serverResponseCode,
                             final byte[] serverResponseBody) {
+    }
+
+    /**
+     * Called when the upload is completed successfully. Override this method to add your own logic.
+     *
+     * @param uploadId unique ID of the upload request
+     * @param serverResponseCode status code returned by the server
+     * @param serverResponseBody byte array containing the response body received from the server.
+     *                           If your server responds with a string, you can get it with
+     *                           {@code new String(serverResponseBody)}. If the string is a
+     *                           JSON, you can parse it using a library such as org.json
+     *                           (embedded in Android) or google's gson
+     * @param redirectLocation Location URL (in response header) sent back from the server in case
+     *                         a redirect is needed (HTTP status codes 3xx). Null if not applicable.
+     */
+    public void onCompleted(final String uploadId, final int serverResponseCode,
+                            final byte[] serverResponseBody, final String redirectLocation) {
     }
 
     /**

--- a/uploadservice/src/main/java/net/gotev/uploadservice/http/HttpConnection.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/http/HttpConnection.java
@@ -57,6 +57,13 @@ public interface HttpConnection {
     byte[] getServerResponseBody() throws IOException;
 
     /**
+     * Gets a server response header value.
+     * @return response header value
+     * @throws IOException if an error occurs while getting the server header value
+     */
+    String getServerResponseHeaderValue(String headerKey) throws IOException;
+
+    /**
      * Closes the connection and frees all the allocated resources.
      */
     void close();

--- a/uploadservice/src/main/java/net/gotev/uploadservice/http/impl/HurlStackConnection.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/http/impl/HurlStackConnection.java
@@ -120,6 +120,11 @@ public class HurlStackConnection implements HttpConnection {
     }
 
     @Override
+    public String getServerResponseHeaderValue(String headerKey) throws IOException {
+        return mConnection.getHeaderField(headerKey);
+    }
+
+    @Override
     public void close() {
         Logger.debug(getClass().getSimpleName(), "closing connection");
 


### PR DESCRIPTION
In case the server response after upload is a redirect (HTTP status 3XX), we now have access to the returned URL located in the response header.