### PR TITLE
Possibility to choose which notification messages should be displayed (on progress, on error, on completed) by the library

### DIFF
--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadNotificationConfig.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadNotificationConfig.java
@@ -69,7 +69,7 @@ public final class UploadNotificationConfig implements Parcelable {
     }
 
     /**
-     * Sets the message to be shown while upload is in progress.
+     * Sets the message to be shown while upload is in progress. Null if no message should be displayed.
      * @param message Message to show
      * @return {@link UploadNotificationConfig}
      */
@@ -79,7 +79,7 @@ public final class UploadNotificationConfig implements Parcelable {
     }
 
     /**
-     * Sets the message to be shown if an error occurs. Null if no error message should be displayed.
+     * Sets the message to be shown if an error occurs. Null if no message should be displayed.
      * @param message Message to show
      * @return {@link UploadNotificationConfig}
      */
@@ -89,7 +89,7 @@ public final class UploadNotificationConfig implements Parcelable {
     }
 
     /**
-     * Sets the message to be shown when the upload is completed.
+     * Sets the message to be shown when the upload is completed. Null if no message should be displayed.
      * @param message Message to show
      * @return {@link UploadNotificationConfig}
      */

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadNotificationConfig.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadNotificationConfig.java
@@ -79,7 +79,7 @@ public final class UploadNotificationConfig implements Parcelable {
     }
 
     /**
-     * Sets the message to be shown if an error occurs.
+     * Sets the message to be shown if an error occurs. Null if no error message should be displayed.
      * @param message Message to show
      * @return {@link UploadNotificationConfig}
      */

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
@@ -475,18 +475,20 @@ public abstract class UploadTask implements Runnable {
 
         notificationManager.cancel(notificationId);
 
-        notification.setContentTitle(replacePlaceholders(params.getNotificationConfig().getTitle(), uploadInfo))
-                .setContentText(replacePlaceholders(params.getNotificationConfig().getErrorMessage(), uploadInfo))
-                .setContentIntent(params.getNotificationConfig().getPendingIntent(service))
-                .setAutoCancel(params.getNotificationConfig().isClearOnAction())
-                .setSmallIcon(params.getNotificationConfig().getIconResourceID())
-                .setGroup(UploadService.NAMESPACE)
-                .setProgress(0, 0, false).setOngoing(false);
-        setRingtone();
+        if (params.getNotificationConfig().getErrorMessage() != null) {
+            notification.setContentTitle(replacePlaceholders(params.getNotificationConfig().getTitle(), uploadInfo))
+                    .setContentText(replacePlaceholders(params.getNotificationConfig().getErrorMessage(), uploadInfo))
+                    .setContentIntent(params.getNotificationConfig().getPendingIntent(service))
+                    .setAutoCancel(params.getNotificationConfig().isClearOnAction())
+                    .setSmallIcon(params.getNotificationConfig().getIconResourceID())
+                    .setGroup(UploadService.NAMESPACE)
+                    .setProgress(0, 0, false).setOngoing(false);
+            setRingtone();
 
-        // this is needed because the main notification used to show progress is ongoing
-        // and a new one has to be created to allow the user to dismiss it
-        notificationManager.notify(notificationId + 1, notification.build());
+            // this is needed because the main notification used to show progress is ongoing
+            // and a new one has to be created to allow the user to dismiss it
+            notificationManager.notify(notificationId + 1, notification.build());
+        }
     }
 
     /**

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
@@ -395,7 +395,7 @@ public abstract class UploadTask implements Runnable {
      * @param uploadInfo upload information and statistics
      */
     private void createNotification(UploadInfo uploadInfo) {
-        if (params.getNotificationConfig() == null) return;
+        if (params.getNotificationConfig() == null || params.getNotificationConfig().getInProgressMessage() == null) return;
 
         notification.setContentTitle(replacePlaceholders(params.getNotificationConfig().getTitle(), uploadInfo))
                 .setContentText(replacePlaceholders(params.getNotificationConfig().getInProgressMessage(), uploadInfo))
@@ -420,7 +420,7 @@ public abstract class UploadTask implements Runnable {
      * @param uploadInfo upload information and statistics
      */
     private void updateNotificationProgress(UploadInfo uploadInfo) {
-        if (params.getNotificationConfig() == null) return;
+        if (params.getNotificationConfig() == null || params.getNotificationConfig().getInProgressMessage() == null) return;
 
         notification.setContentTitle(replacePlaceholders(params.getNotificationConfig().getTitle(), uploadInfo))
                 .setContentText(replacePlaceholders(params.getNotificationConfig().getInProgressMessage(), uploadInfo))
@@ -449,7 +449,7 @@ public abstract class UploadTask implements Runnable {
     }
 
     private void updateNotificationCompleted(UploadInfo uploadInfo) {
-        if (params.getNotificationConfig() == null) return;
+        if (params.getNotificationConfig() == null || params.getNotificationConfig().getCompletedMessage() == null) return;
 
         notificationManager.cancel(notificationId);
 
@@ -471,24 +471,22 @@ public abstract class UploadTask implements Runnable {
     }
 
     private void updateNotificationError(UploadInfo uploadInfo) {
-        if (params.getNotificationConfig() == null) return;
+        if (params.getNotificationConfig() == null || params.getNotificationConfig().getErrorMessage() == null) return;
 
         notificationManager.cancel(notificationId);
 
-        if (params.getNotificationConfig().getErrorMessage() != null) {
-            notification.setContentTitle(replacePlaceholders(params.getNotificationConfig().getTitle(), uploadInfo))
-                    .setContentText(replacePlaceholders(params.getNotificationConfig().getErrorMessage(), uploadInfo))
-                    .setContentIntent(params.getNotificationConfig().getPendingIntent(service))
-                    .setAutoCancel(params.getNotificationConfig().isClearOnAction())
-                    .setSmallIcon(params.getNotificationConfig().getIconResourceID())
-                    .setGroup(UploadService.NAMESPACE)
-                    .setProgress(0, 0, false).setOngoing(false);
-            setRingtone();
+        notification.setContentTitle(replacePlaceholders(params.getNotificationConfig().getTitle(), uploadInfo))
+                .setContentText(replacePlaceholders(params.getNotificationConfig().getErrorMessage(), uploadInfo))
+                .setContentIntent(params.getNotificationConfig().getPendingIntent(service))
+                .setAutoCancel(params.getNotificationConfig().isClearOnAction())
+                .setSmallIcon(params.getNotificationConfig().getIconResourceID())
+                .setGroup(UploadService.NAMESPACE)
+                .setProgress(0, 0, false).setOngoing(false);
+        setRingtone();
 
-            // this is needed because the main notification used to show progress is ongoing
-            // and a new one has to be created to allow the user to dismiss it
-            notificationManager.notify(notificationId + 1, notification.build());
-        }
+        // this is needed because the main notification used to show progress is ongoing
+        // and a new one has to be created to allow the user to dismiss it
+        notificationManager.notify(notificationId + 1, notification.build());
     }
 
     /**


### PR DESCRIPTION
It would be nice to be able to customise error handling without creating multiple notifications. I want to be able to listen to the broadcaster when an error happens and show my own error notifications with different error messages and retry button etc (stuff that is too customised to live in a library). You can currently do this by registering to the broadcast and creating your own notifications, however it will generate two error notifications, as the library also has its own.

My suggestion is simply to have an option to not show the error notification.

I found it logical to add this option by calling `setErrorMessage(null)` if no error message is desired. An alternative approach would be to have another method like `showNotificationOnError(...)` or something similar. I'm fine by either. Thoughts?