### PR TITLE
Fix basic auth error

### DIFF
--- a/uploadservice/src/main/java/net/gotev/uploadservice/HttpUploadRequest.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/HttpUploadRequest.java
@@ -72,7 +72,7 @@ public abstract class HttpUploadRequest extends UploadRequest {
      * @return {@link HttpUploadRequest}
      */
     public HttpUploadRequest setBasicAuth(final String username, final String password) {
-        String auth = Base64.encodeToString((username + ":" + password).getBytes(), Base64.DEFAULT);
+        String auth = Base64.encodeToString((username + ":" + password).getBytes(), Base64.NO_WRAP);
         httpParams.addRequestHeader("Authorization", "Basic " + auth);
         return this;
     }


### PR DESCRIPTION
When using basic auth I was getting an error about a newline character in the header, I looked into it and `Base64.DEFAULT` adds a newline char to the end of the string. Using `.No_WRAP` avoids this.