### PR TITLE
Fix exception

### DIFF
--- a/uploadservice/src/main/java/net/gotev/uploadservice/schemehandlers/SchemeHandlerFactory.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/schemehandlers/SchemeHandlerFactory.java
@@ -28,9 +28,10 @@ public class SchemeHandlerFactory {
     public SchemeHandler get(String path)
             throws NoSuchMethodException, IllegalAccessException,
                    InvocationTargetException, InstantiationException {
+
         for (Map.Entry<String, Class<? extends SchemeHandler>> handler : handlers.entrySet()) {
             if (path.startsWith(handler.getKey())) {
-                return handler.getValue().getConstructor(String.class).newInstance(path);
+                return handler.getValue().getDeclaredConstructor(String.class).newInstance(path);
             }
         }
 


### PR DESCRIPTION
Fix for #216.

I noticed URI support was merged into master, tried it out but the app would crash due to `NoSuchMethodException`.

The `SchemeHandler` constructors are package private, `getConstructor` only gets public  constructors, `getDeclaredConstructor` must be used.