### PR TITLE
Adding ability to set the notification icon colours.

### DIFF
--- a/examples/app/app/src/main/java/net/gotev/uploadservicedemo/MainActivity.java
+++ b/examples/app/app/src/main/java/net/gotev/uploadservicedemo/MainActivity.java
@@ -2,6 +2,7 @@ package net.gotev.uploadservicedemo;
 
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -90,6 +91,10 @@ public class MainActivity extends FilesPickerActivity implements UploadStatusDel
                 .setCompletedIcon(R.drawable.ic_upload_success)
                 .setErrorIcon(R.drawable.ic_upload_error)
                 .setCancelledIcon(R.drawable.ic_cancelled)
+                .setIconColor(Color.BLUE)
+                .setCompletedIconColor(Color.GREEN)
+                .setErrorIconColor(Color.RED)
+                .setCancelledIconColor(Color.YELLOW)
                 .setTitle(filename)
                 .setInProgressMessage(getString(R.string.uploading))
                 .setCompletedMessage(getString(R.string.upload_success))

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadNotificationConfig.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadNotificationConfig.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.v4.app.NotificationCompat;
 
 /**
  * Contains the configuration of the upload notification.
@@ -17,6 +18,10 @@ public final class UploadNotificationConfig implements Parcelable {
     private int completedIconResourceID;
     private int errorIconResourceID;
     private int cancelledIconResourceID;
+    private int iconColorResourceID;
+    private int completedIconColorResourceID;
+    private int errorIconColorResourceID;
+    private int cancelledIconColorResourceID;
     private String title;
     private String inProgress;
     private String completed;
@@ -47,6 +52,10 @@ public final class UploadNotificationConfig implements Parcelable {
         completedIconResourceID = iconResourceID;
         errorIconResourceID = iconResourceID;
         cancelledIconResourceID = iconResourceID;
+        iconColorResourceID = NotificationCompat.COLOR_DEFAULT;
+        completedIconColorResourceID = iconColorResourceID;
+        errorIconColorResourceID = iconColorResourceID;
+        cancelledIconColorResourceID = iconColorResourceID;
         title = "File Upload";
         inProgress = "Uploading at " + Placeholders.UPLOAD_RATE + " (" + Placeholders.PROGRESS + ")";
         completed = "Upload completed successfully in " + Placeholders.ELAPSED_TIME;
@@ -100,6 +109,49 @@ public final class UploadNotificationConfig implements Parcelable {
      */
     public final UploadNotificationConfig setCancelledIcon(int resourceID) {
         cancelledIconResourceID = resourceID;
+        return this;
+    }
+
+    /**
+     * Sets the notification icon color.
+     * @param resourceID Resource ID of the color to use
+     * @return {@link UploadNotificationConfig}
+     */
+    public final UploadNotificationConfig setIconColor(int resourceID) {
+        this.iconColorResourceID = resourceID;
+        return this;
+    }
+
+    /**
+     * Sets the icon color to show in the notification when the operation is completed successfully.
+     * By default it's the same as the icon color used while the operation is in progress.
+     * @param resourceID Resource ID of the color to use
+     * @return {@link UploadNotificationConfig}
+     */
+    public final UploadNotificationConfig setCompletedIconColor(int resourceID) {
+        this.completedIconColorResourceID = resourceID;
+        return this;
+    }
+
+    /**
+     * Sets the icon color to show in the notification when an error happens.
+     * By default it's the same as the icon color used while the operation is in progress.
+     * @param resourceID Resource ID of the color to use
+     * @return {@link UploadNotificationConfig}
+     */
+    public final UploadNotificationConfig setErrorIconColor(int resourceID) {
+        this.errorIconColorResourceID = resourceID;
+        return this;
+    }
+
+    /**
+     * Sets the icon color to show in the notification when the upload is cancelled.
+     * By default it's the same as the icon color used while the operation is in progress.
+     * @param resourceID Resource ID of the color to use
+     * @return {@link UploadNotificationConfig}
+     */
+    public final UploadNotificationConfig setCancelledIconColor(int resourceID) {
+        this.cancelledIconColorResourceID = resourceID;
         return this;
     }
 
@@ -231,6 +283,22 @@ public final class UploadNotificationConfig implements Parcelable {
         return cancelledIconResourceID;
     }
 
+    final int getIconColorResourceID() {
+        return iconColorResourceID;
+    }
+
+    final int getCompletedIconColorResourceID() {
+        return completedIconColorResourceID;
+    }
+
+    final int getErrorIconColorResourceID() {
+        return errorIconColorResourceID;
+    }
+
+    final int getCancelledIconColorResourceID() {
+        return cancelledIconColorResourceID;
+    }
+
     final String getTitle() {
         return title;
     }
@@ -305,6 +373,10 @@ public final class UploadNotificationConfig implements Parcelable {
         parcel.writeInt(completedIconResourceID);
         parcel.writeInt(errorIconResourceID);
         parcel.writeInt(cancelledIconResourceID);
+        parcel.writeInt(iconColorResourceID);
+        parcel.writeInt(completedIconColorResourceID);
+        parcel.writeInt(errorIconColorResourceID);
+        parcel.writeInt(cancelledIconColorResourceID);
         parcel.writeString(title);
         parcel.writeString(inProgress);
         parcel.writeString(completed);
@@ -323,6 +395,10 @@ public final class UploadNotificationConfig implements Parcelable {
         completedIconResourceID = in.readInt();
         errorIconResourceID = in.readInt();
         cancelledIconResourceID = in.readInt();
+        iconColorResourceID = in.readInt();
+        completedIconColorResourceID = in.readInt();
+        errorIconColorResourceID = in.readInt();
+        cancelledIconColorResourceID = in.readInt();
         title = in.readString();
         inProgress = in.readString();
         completed = in.readString();

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
@@ -297,11 +297,13 @@ public abstract class UploadTask implements Runnable {
         if (successfulUpload) {
             updateNotification(uploadInfo, notificationConfig.getCompletedMessage(),
                     notificationConfig.isAutoClearOnSuccess(),
-                    notificationConfig.getCompletedIconResourceID());
+                    notificationConfig.getCompletedIconResourceID(),
+                    notificationConfig.getCompletedIconColorResourceID());
         } else {
             updateNotification(uploadInfo, notificationConfig.getErrorMessage(),
                     notificationConfig.isAutoClearOnError(),
-                    notificationConfig.getErrorIconResourceID());
+                    notificationConfig.getErrorIconResourceID(),
+                    notificationConfig.getErrorIconColorResourceID());
         }
 
         service.taskCompleted(params.getId());
@@ -343,7 +345,8 @@ public abstract class UploadTask implements Runnable {
 
         updateNotification(uploadInfo, notificationConfig.getCancelledMessage(),
                 notificationConfig.isAutoClearOnCancel(),
-                notificationConfig.getCancelledIconResourceID());
+                notificationConfig.getCancelledIconResourceID(),
+                notificationConfig.getCancelledIconColorResourceID());
 
         service.taskCompleted(params.getId());
     }
@@ -409,7 +412,8 @@ public abstract class UploadTask implements Runnable {
 
         updateNotification(uploadInfo, notificationConfig.getErrorMessage(),
                 notificationConfig.isAutoClearOnError(),
-                notificationConfig.getErrorIconResourceID());
+                notificationConfig.getErrorIconResourceID(),
+                notificationConfig.getErrorIconColorResourceID());
 
         service.taskCompleted(params.getId());
     }
@@ -426,6 +430,7 @@ public abstract class UploadTask implements Runnable {
                 .setContentText(Placeholders.replace(params.getNotificationConfig().getInProgressMessage(), uploadInfo))
                 .setContentIntent(params.getNotificationConfig().getPendingIntent(service))
                 .setSmallIcon(params.getNotificationConfig().getIconResourceID())
+                .setColor(params.getNotificationConfig().getIconColorResourceID())
                 .setGroup(UploadService.NAMESPACE)
                 .setProgress(100, 0, true)
                 .setOngoing(true);
@@ -451,6 +456,7 @@ public abstract class UploadTask implements Runnable {
                 .setContentText(Placeholders.replace(params.getNotificationConfig().getInProgressMessage(), uploadInfo))
                 .setContentIntent(params.getNotificationConfig().getPendingIntent(service))
                 .setSmallIcon(params.getNotificationConfig().getIconResourceID())
+                .setColor(params.getNotificationConfig().getIconColorResourceID())
                 .setGroup(UploadService.NAMESPACE)
                 .setProgress((int)uploadInfo.getTotalBytes(), (int)uploadInfo.getUploadedBytes(), false)
                 .setOngoing(true);
@@ -475,7 +481,8 @@ public abstract class UploadTask implements Runnable {
 
     private void updateNotification(UploadInfo uploadInfo, String message,
                                     boolean autoClearOnSuccess,
-                                    int iconResourceID) {
+                                    int iconResourceID,
+                                    int iconColorResourceID) {
         if (params.getNotificationConfig() == null) return;
 
         notificationManager.cancel(notificationId);
@@ -488,6 +495,7 @@ public abstract class UploadTask implements Runnable {
                     .setContentIntent(params.getNotificationConfig().getPendingIntent(service))
                     .setAutoCancel(params.getNotificationConfig().isClearOnAction())
                     .setSmallIcon(iconResourceID)
+                    .setColor(iconColorResourceID)
                     .setGroup(UploadService.NAMESPACE)
                     .setProgress(0, 0, false)
                     .setOngoing(false);


### PR DESCRIPTION
I've added the ability to set the notification icon background colours through UploadNotificationConfig:

```
UploadNotificationConfig
	.setIconColor(Color.BLUE)
	.setCompletedIconColor(Color.GREEN)
	.setErrorIconColor(Color.RED)
	.setCancelledIconColor(Color.YELLOW)
```
	
Like icons if individual "completed", "error" and "cancelled" colours aren't specified they fallback to "iconColor". If this isn't specified it falls back to the notification compat default (NotificationCompat.COLOR_DEFAULT).

Screenshot:
![upload colours](https://cloud.githubusercontent.com/assets/63985/22331953/1d1b34ec-e3c6-11e6-8417-715759bc3ec5.png)

Enjoy!