### PR TITLE
Removing enforcement of permission WRITE_EXTERNAL_STORAGE

### DIFF
--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
@@ -128,15 +128,6 @@ public abstract class UploadTask implements Runnable {
     @Override
     public final void run() {
 
-        if (!params.getFiles().isEmpty() && Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1) {
-            int permissionCheck = ContextCompat.checkSelfPermission(service,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE);
-            if (permissionCheck == PackageManager.PERMISSION_DENIED) {
-                broadcastError(new RuntimeException("Please request " + Manifest.permission.WRITE_EXTERNAL_STORAGE + " permission before performing the request! Check this: https://gist.github.com/gotev/67c300c563bdf68a502c"));
-                return;
-            }
-        }
-
         createNotification(new UploadInfo(params.getId()));
 
         attempts = 0;


### PR DESCRIPTION
This shouldn't be the library's responsibility. An app does not always need this permission to upload files (eg. the app generates its own images in an internal folder and does not ask the user to select files from the device).