### PR TITLE
Force a fixed version of okhttp to 3.7.0

### DIFF
--- a/uploadservice-okhttp/build.gradle
+++ b/uploadservice-okhttp/build.gradle
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    compile 'com.squareup.okhttp3:okhttp:3.+'
+    compile 'com.squareup.okhttp3:okhttp:3.7.0'
     //compile "net.gotev:uploadservice:${version}"
     //comment the previous line and uncomment the next line for development (it uses the local lib)
     compile project(':uploadservice')


### PR DESCRIPTION
The new version 3.8.0 enforce null checks, and it broke all my test because your library was using 3.+ which took the latest version that just came out.

It really is bad practice to use a + in dependencies.