### PR TITLE
Fix uploadedBytes calculation in MultipartUploadTask

### DIFF
--- a/uploadservice/src/main/java/net/gotev/uploadservice/MultipartUploadTask.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/MultipartUploadTask.java
@@ -65,6 +65,8 @@ public class MultipartUploadTask extends HttpUploadTask {
         writeRequestParameters(bodyWriter);
         writeFiles(bodyWriter);
         bodyWriter.write(trailerBytes);
+        uploadedBytes += trailerBytes.length;
+        broadcastProgress(uploadedBytes, totalBytes);
     }
 
     private long getFilesLength() throws UnsupportedEncodingException {
@@ -139,7 +141,10 @@ public class MultipartUploadTask extends HttpUploadTask {
             broadcastProgress(uploadedBytes, totalBytes);
 
             bodyWriter.writeStream(file.getStream(service), this);
-            bodyWriter.write(NEW_LINE.getBytes(charset));
+
+            byte[] newLineBytes = NEW_LINE.getBytes(charset);
+            bodyWriter.write(newLineBytes);
+            uploadedBytes += newLineBytes.length;
         }
     }
 

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
@@ -218,7 +218,7 @@ public abstract class UploadTask implements Runnable {
     protected final void broadcastProgress(final long uploadedBytes, final long totalBytes) {
 
         long currentTime = System.currentTimeMillis();
-        if (currentTime < lastProgressNotificationTime + UploadService.PROGRESS_REPORT_INTERVAL) {
+        if (uploadedBytes < totalBytes && currentTime < lastProgressNotificationTime + UploadService.PROGRESS_REPORT_INTERVAL) {
             return;
         }
 


### PR DESCRIPTION
MultipartUploadTask never broadcasts 100% progress. User can see 93% progress or so, but the files are already uploaded to the server. In case of network issue uploading failure is popped up and when connection becomes ok file duplicates appear - first file from the server and second one (local) pending uploading. 
