### PR TITLE
ftp remote filename handled incorrectly

### DIFF
--- a/uploadservice-ftp/src/main/java/net/gotev/uploadservice/ftp/FTPUploadTask.java
+++ b/uploadservice-ftp/src/main/java/net/gotev/uploadservice/ftp/FTPUploadTask.java
@@ -170,7 +170,7 @@ public class FTPUploadTask extends UploadTask implements CopyStreamListener {
         String remoteDestination = file.getProperty(PARAM_REMOTE_PATH);
 
         if (remoteDestination.startsWith(baseWorkingDir)) {
-            remoteDestination = remoteDestination.replace(baseWorkingDir, "");
+            remoteDestination = remoteDestination.substring(baseWorkingDir.length());
         }
 
         makeDirectories(remoteDestination, ftpParams.createdDirectoriesPermissions);


### PR DESCRIPTION
with baseWorkingDir="/", filename "/one/two/three.zip" is changed to "onetwothree.zip", which is not how it should be, it should be changed to "one/two/three.zip" instead