### PR TITLE
Fix for the ConcurrentModificationException in the FTPUploadTask

### DIFF
--- a/uploadservice-ftp/src/main/java/net/gotev/uploadservice/ftp/FTPUploadTask.java
+++ b/uploadservice-ftp/src/main/java/net/gotev/uploadservice/ftp/FTPUploadTask.java
@@ -18,6 +18,7 @@ import org.apache.commons.net.io.CopyStreamListener;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Iterator;
 
 /**
@@ -110,7 +111,7 @@ public class FTPUploadTask extends UploadTask implements CopyStreamListener {
             String baseWorkingDir = ftpClient.printWorkingDirectory();
             Logger.debug(LOG_TAG, "FTP default working directory is: " + baseWorkingDir);
 
-            Iterator<UploadFile> iterator = params.files.iterator();
+            Iterator<UploadFile> iterator = new ArrayList<>(params.files).iterator();
             while (iterator.hasNext()) {
                 UploadFile file = iterator.next();
 


### PR DESCRIPTION
* to prevent the `concurrentModificationException` we can make a copy of the list before getting it's iterator
  * FIXES https://github.com/gotev/android-upload-service/issues/310