### PR TITLE
Fixing continuous bleep during uploading on API >= 26

### DIFF
--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
@@ -133,6 +133,10 @@ public abstract class UploadTask implements Runnable {
 
             if (notificationManager.getNotificationChannel(notificationChannelId) == null) {
                 NotificationChannel channel = new NotificationChannel(notificationChannelId, "Upload Service channel", NotificationManager.IMPORTANCE_LOW);
+                if (!params.notificationConfig.isRingToneEnabled()) {
+                    // Disable sound
+                    channel.setSound(null, null);
+                }
                 notificationManager.createNotificationChannel(channel);
             }
         }

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.java
@@ -134,7 +134,6 @@ public abstract class UploadTask implements Runnable {
             if (notificationManager.getNotificationChannel(notificationChannelId) == null) {
                 NotificationChannel channel = new NotificationChannel(notificationChannelId, "Upload Service channel", NotificationManager.IMPORTANCE_LOW);
                 if (!params.notificationConfig.isRingToneEnabled()) {
-                    // Disable sound
                     channel.setSound(null, null);
                 }
                 notificationManager.createNotificationChannel(channel);


### PR DESCRIPTION
The notification sound is being fired continuously during uploading on API >=26. Due to the changes to the notification channels.

Fixing this by setting the sound of the channel off when `notificationConfig.isRingToneEnabled()` equals `false`.

Related issues (closed, but still occuring in v4.3.1): #324, #351, #372