### PR TITLE
Fixed issue where notification ids could be reused

### DIFF
--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadService.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadService.java
@@ -131,7 +131,7 @@ public final class UploadService extends Service {
 
     // internal variables
     private PowerManager.WakeLock wakeLock;
-    private int notificationIncrementalId = 0;
+    private static int notificationIncrementalId = 0;
     private static final Map<String, UploadTask> uploadTasksMap = new ConcurrentHashMap<>();
     private static final Map<String, WeakReference<UploadStatusDelegate>> uploadDelegates = new ConcurrentHashMap<>();
     private final BlockingQueue<Runnable> uploadTasksQueue = new LinkedBlockingQueue<>();


### PR DESCRIPTION
Addresses issue #392 
Made notificationIncrementalId static, so that it could be used for the
lifetime of the app process, rather than just the life of the Service
instance.