### PR TITLE
Allow non-uppercase HTTP methods

### DIFF
--- a/uploadservice/src/main/java/net/gotev/uploadservice/HttpUploadRequest.java
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/HttpUploadRequest.java
@@ -122,7 +122,7 @@ public abstract class HttpUploadRequest<B extends HttpUploadRequest<B>>
      * @return self instance
      */
     public B setMethod(final String method) {
-        httpParams.method = method;
+        httpParams.method = method.toUpperCase();
         return self();
     }
 


### PR DESCRIPTION
Setting "post" instead of "POST" as the HTTP method is an annoying mistake, since the library doesn't complain about it. This solves it nicely and doesn't make anything more complex.