### PR TITLE
Add placeholder formatter

### DIFF
--- a/examples/app/demoapp/src/main/java/net/gotev/uploadservicedemo/App.java
+++ b/examples/app/demoapp/src/main/java/net/gotev/uploadservicedemo/App.java
@@ -11,11 +11,14 @@ import android.util.Log;
 import com.facebook.stetho.Stetho;
 import com.facebook.stetho.okhttp3.StethoInterceptor;
 
+import net.gotev.uploadservice.Placeholders;
 import net.gotev.uploadservice.UploadServiceConfig;
 import net.gotev.uploadservice.data.RetryPolicyConfig;
 import net.gotev.uploadservice.logger.UploadServiceLogger;
 import net.gotev.uploadservice.observer.request.RequestObserver;
 import net.gotev.uploadservice.okhttp.OkHttpStack;
+
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -62,6 +65,19 @@ public class App extends Application {
 
         // Set upload service debug log messages level
         UploadServiceLogger.setDevelopmentMode(BuildConfig.DEBUG);
+
+        // Set custom placeholder formatter
+        Placeholders.setFormatter(new Placeholders.DefaultFormatter(){
+            @NotNull
+            @Override
+            public String formatTotalFiles(final int count) {
+                return getResources().getQuantityString(
+                    R.plurals.uploading_total_files_count,
+                    count,
+                    count
+                );
+            }
+        });
 
         createNotificationChannel();
 

--- a/examples/app/demoapp/src/main/res/values/strings.xml
+++ b/examples/app/demoapp/src/main/res/values/strings.xml
@@ -26,7 +26,15 @@
     <string name="cancel">Cancel</string>
     <string name="info">Info</string>
     <string name="uploading">Uploaded [[UPLOADED_FILES]] of [[TOTAL_FILES]] at [[UPLOAD_RATE]] - [[PROGRESS]]</string>
-    <string name="upload_success">Upload completed successfully in [[ELAPSED_TIME]]</string>
+    <string name="upload_success">Upload of [[TOTAL_FILES]] completed successfully in [[ELAPSED_TIME]]</string>
+    <plurals name="uploading_total_files_count">
+        <item quantity="zero">%d files</item>
+        <item quantity="one">%d file</item>
+        <item quantity="two">%d files</item>
+        <item quantity="few">%d files</item>
+        <item quantity="many">%d files</item>
+        <item quantity="other">%d files</item>
+    </plurals>
     <string name="upload_error">Error while uploading</string>
     <string name="upload_cancelled">Upload has been cancelled</string>
     <string name="multipart_upload">Multipart Upload</string>

--- a/uploadservice/src/main/java/net/gotev/uploadservice/Placeholders.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/Placeholders.kt
@@ -42,10 +42,105 @@ object Placeholders {
     fun replace(string: String?, uploadInfo: UploadInfo): String {
         val safeString = string ?: return ""
 
-        return safeString.replace(ELAPSED_TIME, uploadInfo.elapsedTimeString)
-            .replace(PROGRESS, "${uploadInfo.progressPercent}%")
-            .replace(UPLOAD_RATE, uploadInfo.uploadRateString)
-            .replace(UPLOADED_FILES, uploadInfo.successfullyUploadedFiles.toString())
-            .replace(TOTAL_FILES, uploadInfo.files.size.toString())
+        return safeString.replace(ELAPSED_TIME, formatter.formatElapsedTime(uploadInfo.elapsedTime))
+            .replace(PROGRESS, formatter.formatProgress(uploadInfo.progressPercent))
+            .replace(UPLOAD_RATE, formatter.formatUploadRate(uploadInfo.uploadRate))
+            .replace(UPLOADED_FILES, formatter.formatUploadedFiles(uploadInfo.successfullyUploadedFiles))
+            .replace(TOTAL_FILES, formatter.formatTotalFiles(uploadInfo.files.size))
+    }
+
+    @JvmStatic
+    var formatter: Formatter = DefaultFormatter()
+
+    interface Formatter {
+        /**
+         * Gets the elapsed time as a string.
+         * @param elapsedTime elapsed time in milliseconds
+         * @return string representation of the elapsed time
+         */
+        fun formatElapsedTime(elapsedTime: Long): String
+
+        /**
+         * Gets the upload progress as a string.
+         * @param progress upload progress in percents
+         * @return string representation of the upload progress
+         */
+        fun formatProgress(progress: Int): String
+
+        /**
+         * Returns a string representation of the upload rate.
+         * @param uploadRate upload rate in Kb/s (Kilo bit per second).
+         * @return string representation of the upload rate
+         */
+        fun formatUploadRate(uploadRate: Double): String
+
+        /**
+         * Gets the uploaded files count as a string.
+         * It can be used to pluralize strings (e.g. 1 file, 2 files).
+         * @param count count of uploaded files
+         * @return string representation of the uploaded files count
+         */
+        fun formatUploadedFiles(count: Int): String
+
+        /**
+         * Gets the total files count as a string.
+         * It can be used to pluralize strings (e.g. 1 file, 2 files).
+         * @param count total count of files
+         * @return string representation of the total files count
+         */
+        fun formatTotalFiles(count: Int): String
+    }
+
+    open class DefaultFormatter : Formatter {
+        /**
+         * Gets the elapsed time as a string, expressed in seconds if the value is `< 60`,
+         * or expressed in minutes and seconds if the value is `>=` 60.
+         * @param elapsedTime The elapsed time in milliseconds
+         * @return string representation of the elapsed time
+         */
+        override fun formatElapsedTime(elapsedTime: Long): String {
+            var elapsedSeconds = (elapsedTime / 1000).toInt()
+
+            if (elapsedSeconds == 0) return "0 sec"
+
+            val minutes = elapsedSeconds / 60
+            elapsedSeconds -= 60 * minutes
+
+            return if (minutes == 0) {
+                "$elapsedSeconds sec"
+            } else {
+                "$minutes min $elapsedSeconds sec"
+            }
+        }
+
+        override fun formatProgress(progress: Int): String {
+            return "$progress%"
+        }
+
+        /**
+         * Returns a string representation of the upload rate, expressed in the most convenient unit of
+         * measurement (Mbit/s if the value is `>=` 1024, B/s if the value is `< 1`, otherwise Kbit/s).
+         * @param uploadRate upload rate in Kb/s (Kilo bit per second).
+         * @return string representation of the upload rate (e.g. 234 Kbit/s)
+         */
+        override fun formatUploadRate(uploadRate: Double): String {
+            if (uploadRate < 1) {
+                return "${(uploadRate * 1000).toInt()} bit/s"
+            }
+
+            if (uploadRate >= 1024) {
+                return "${(uploadRate / 1024).toInt()} Mb/s"
+            }
+
+            return "${uploadRate.toInt()} Kb/s"
+        }
+
+        override fun formatUploadedFiles(count: Int): String {
+            return count.toString()
+        }
+
+        override fun formatTotalFiles(count: Int): String {
+            return count.toString()
+        }
     }
 }

--- a/uploadservice/src/main/java/net/gotev/uploadservice/data/UploadInfo.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/data/UploadInfo.kt
@@ -52,28 +52,6 @@ data class UploadInfo @JvmOverloads constructor(
         get() = currentTime - startTime
 
     /**
-     * Gets the elapsed time as a string, expressed in seconds if the value is `< 60`,
-     * or expressed in minutes and seconds if the value is `>=` 60.
-     * @return string representation of the elapsed time
-     */
-    @IgnoredOnParcel
-    val elapsedTimeString: String
-        get() {
-            var elapsedSeconds = (elapsedTime / 1000).toInt()
-
-            if (elapsedSeconds == 0) return "0 sec"
-
-            val minutes = elapsedSeconds / 60
-            elapsedSeconds -= 60 * minutes
-
-            return if (minutes == 0) {
-                "$elapsedSeconds sec"
-            } else {
-                "$minutes min $elapsedSeconds sec"
-            }
-        }
-
-    /**
      * Gets the average upload rate in Kb/s (Kilo bit per second).
      * @return upload rate
      */
@@ -84,25 +62,6 @@ data class UploadInfo @JvmOverloads constructor(
             if (elapsedTime < 1000) return 0.0
 
             return uploadedBytes.toDouble() / 1024 * 8 / (elapsedTime / 1000)
-        }
-
-    /**
-     * Returns a string representation of the upload rate, expressed in the most convenient unit of
-     * measurement (Mbit/s if the value is `>=` 1024, B/s if the value is `< 1`, otherwise Kbit/s)
-     * @return string representation of the upload rate (e.g. 234 Kbit/s)
-     */
-    @IgnoredOnParcel
-    val uploadRateString: String
-        get() {
-            if (uploadRate < 1) {
-                return "${(uploadRate * 1000).toInt()} bit/s"
-            }
-
-            if (uploadRate >= 1024) {
-                return "${(uploadRate / 1024).toInt()} Mb/s"
-            }
-
-            return "${uploadRate.toInt()} Kb/s"
         }
 
     /**


### PR DESCRIPTION
https://github.com/gotev/android-upload-service/issues/463#issuecomment-544989334

Maybe I should make the formatter more abstract, and not tied to `Placeholders`. And keep `UploadInfo` fields for backward compatibility.