### PR TITLE
Service Lifecycle improvements

### DIFF
--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadService.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadService.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.IBinder
 import android.os.PowerManager
+import androidx.core.app.NotificationCompat
 import net.gotev.uploadservice.UploadServiceConfig.threadPool
 import net.gotev.uploadservice.extensions.acquirePartialWakeLock
 import net.gotev.uploadservice.extensions.getUploadTask
@@ -191,6 +192,14 @@ class UploadService : Service() {
 
         wakeLock = acquirePartialWakeLock(wakeLock, TAG)
         notificationActionsObserver.register()
+
+        val notification = NotificationCompat.Builder(this, UploadServiceConfig.defaultNotificationChannel!!)
+            .setSmallIcon(android.R.drawable.ic_menu_upload)
+            .setOngoing(true)
+            .setGroup(UploadServiceConfig.namespace)
+            .build()
+
+        startForeground(UPLOAD_NOTIFICATION_BASE_ID, notification)
     }
 
     override fun onBind(intent: Intent): IBinder? {


### PR DESCRIPTION
prevent `android.app.RemoteServiceException: Context.startForegroundService() did not then call Service.startForeground()` from happening