### PR TITLE
Removed WRITE_EXTERNAL_STORAGE permission from library manifest

### DIFF
--- a/examples/app/demoapp/src/main/AndroidManifest.xml
+++ b/examples/app/demoapp/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="net.gotev.uploadservicedemo">
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <application
         android:name=".App"
         android:allowBackup="true"

--- a/uploadservice/src/main/AndroidManifest.xml
+++ b/uploadservice/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="net.gotev.uploadservice">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
Relevant issue https://github.com/gotev/android-upload-service/issues/254#issuecomment-827970851