### PR TITLE
Fixes for crashes on apps targeting Android 12

### DIFF
--- a/examples/app/demoapp/src/main/java/net/gotev/uploadservicedemo/activities/BaseActivity.kt
+++ b/examples/app/demoapp/src/main/java/net/gotev/uploadservicedemo/activities/BaseActivity.kt
@@ -31,9 +31,14 @@ open class BaseActivity : AppCompatActivity() {
         uploadId: String,
         @StringRes title: Int
     ): UploadNotificationConfig {
+        var flags = PendingIntent.FLAG_ONE_SHOT
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            flags = flags or PendingIntent.FLAG_IMMUTABLE
+        }
         val clickIntent = PendingIntent.getActivity(
-            this, 1, Intent(this, MainActivity::class.java), PendingIntent.FLAG_UPDATE_CURRENT
+            this, 1, Intent(this, MainActivity::class.java), flags
         )
+
 
         val autoClear = false
         val largeIcon: Bitmap? = null

--- a/manifest.gradle
+++ b/manifest.gradle
@@ -12,7 +12,7 @@ ext {
     library_version = '4.6.0'
     version_code = 47
     min_sdk = 21
-    target_sdk = 30
+    target_sdk = 31
     demo_app_id = 'net.gotev.uploadservicedemo'
 
     // Gradle classpath dependencies versions

--- a/uploadservice/src/main/java/net/gotev/uploadservice/data/UploadNotificationStatusConfig.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/data/UploadNotificationStatusConfig.kt
@@ -4,6 +4,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
+import android.os.Build
 import android.os.Parcelable
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
@@ -68,11 +69,15 @@ data class UploadNotificationStatusConfig @JvmOverloads constructor(
     val onDismissed: PendingIntent? = null
 ) : Parcelable {
     fun getClickIntent(context: Context): PendingIntent {
+        var flags = PendingIntent.FLAG_UPDATE_CURRENT
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            flags = flags or PendingIntent.FLAG_IMMUTABLE
+        }
         return clickIntent ?: PendingIntent.getBroadcast(
             context,
             0,
             Intent(),
-            PendingIntent.FLAG_UPDATE_CURRENT
+            flags
         )
     }
 }

--- a/uploadservice/src/main/java/net/gotev/uploadservice/extensions/ContextExtensions.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/extensions/ContextExtensions.kt
@@ -200,13 +200,17 @@ fun Context.getNotificationActionIntent(
         putExtra(uploadIdKey, uploadId)
     }
 
+    var flags = PendingIntent.FLAG_ONE_SHOT
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        flags = flags or PendingIntent.FLAG_IMMUTABLE
+    }
     return PendingIntent.getBroadcast(
         this,
         // this is to prevent duplicate PendingIntent request codes which can cause cancelling
         // the wrong upload
         uploadId.hashCode(),
         intent,
-        PendingIntent.FLAG_ONE_SHOT
+        flags
     )
 }
 


### PR DESCRIPTION
Added mutability flags to PendingIntents required for apps  Android 12. Not sure if those are all changes required to properly support Android 12, but library seems to work fine after fix.
#604 