### PR TITLE
Resolving Jitpack build failure for v4.7.0

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
Adding jitpack.yml for java 11. This will ensure that jitpack uses java 11 while running gradle. 