### PR TITLE
okhttp: Update to latest 4.9.X

### DIFF
--- a/uploadservice-okhttp/build.gradle
+++ b/uploadservice-okhttp/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    api 'com.squareup.okhttp3:okhttp:4.9.2'
+    api 'com.squareup.okhttp3:okhttp:4.9.3'
     //api "net.gotev:uploadservice:${version}"
     //comment the previous line and uncomment the next line for development (it uses the local lib)
     api project(':uploadservice')


### PR DESCRIPTION
There is an http2 bug which has been fixed in 4.9.3. 

See https://square.github.io/okhttp/changelogs/changelog_4x/#version-493 

The diff between 4.9.2 and 4.9.3 seems pretty safe https://github.com/square/okhttp/pull/6293