### PR TITLE
Add support for Android 34 (#642)

### DIFF
--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadService.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadService.kt
@@ -182,7 +182,7 @@ class UploadService : Service() {
 
         if (UploadServiceConfig.isForegroundService && uploadTasksMap.isEmpty()) {
             UploadServiceLogger.debug(TAG, NA) { "All tasks completed, stopping foreground execution" }
-            stopForeground(true)
+            stopForeground(STOP_FOREGROUND_REMOVE)
             shutdownIfThereArentAnyActiveTasks()
         }
     }
@@ -248,7 +248,7 @@ class UploadService : Service() {
 
         if (UploadServiceConfig.isForegroundService) {
             UploadServiceLogger.debug(TAG, NA) { "Stopping foreground execution" }
-            stopForeground(true)
+            stopForeground(STOP_FOREGROUND_REMOVE)
         }
 
         wakeLock.safeRelease()

--- a/uploadservice/src/main/java/net/gotev/uploadservice/data/BroadcastData.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/data/BroadcastData.kt
@@ -1,6 +1,7 @@
 package net.gotev.uploadservice.data
 
 import android.content.Intent
+import android.os.Build
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import net.gotev.uploadservice.UploadServiceConfig
@@ -17,7 +18,11 @@ internal data class BroadcastData @JvmOverloads constructor(
         private const val paramName = "broadcastData"
 
         fun fromIntent(intent: Intent): BroadcastData? {
-            return intent.getParcelableExtra(paramName)
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(paramName, BroadcastData::class.java)
+            } else {
+                intent.getParcelableExtra(paramName)
+            }
         }
     }
 

--- a/uploadservice/src/main/java/net/gotev/uploadservice/observer/request/BaseRequestObserver.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/observer/request/BaseRequestObserver.kt
@@ -2,7 +2,9 @@ package net.gotev.uploadservice.observer.request
 
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
+import android.os.Build
 import net.gotev.uploadservice.UploadServiceConfig
 import net.gotev.uploadservice.data.BroadcastData
 import net.gotev.uploadservice.data.UploadInfo
@@ -33,7 +35,13 @@ open class BaseRequestObserver(
     }
 
     open fun register() {
-        context.registerReceiver(this, UploadServiceConfig.broadcastStatusIntentFilter)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(
+                this, UploadServiceConfig.broadcastStatusIntentFilter, RECEIVER_NOT_EXPORTED
+            )
+        } else {
+            context.registerReceiver(this, UploadServiceConfig.broadcastStatusIntentFilter)
+        }
     }
 
     open fun unregister() {

--- a/uploadservice/src/main/java/net/gotev/uploadservice/observer/request/NotificationActionsObserver.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/observer/request/NotificationActionsObserver.kt
@@ -3,7 +3,9 @@ package net.gotev.uploadservice.observer.request
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import net.gotev.uploadservice.UploadService
+import net.gotev.uploadservice.UploadServiceConfig
 import net.gotev.uploadservice.UploadServiceConfig.broadcastNotificationAction
 import net.gotev.uploadservice.UploadServiceConfig.broadcastNotificationActionIntentFilter
 import net.gotev.uploadservice.extensions.uploadIdToCancel
@@ -28,7 +30,13 @@ open class NotificationActionsObserver(
     }
 
     fun register() {
-        context.registerReceiver(this, broadcastNotificationActionIntentFilter)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(
+                this, broadcastNotificationActionIntentFilter, Context.RECEIVER_NOT_EXPORTED
+            )
+        } else {
+            context.registerReceiver(this, broadcastNotificationActionIntentFilter)
+        }
         UploadServiceLogger.debug(NotificationActionsObserver::class.java.simpleName, NA) {
             "registered"
         }


### PR DESCRIPTION
- Fix issue - '` java.lang.SecurityException: ************: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts` caused on Android 14.
- Remove deprecated code, or added alternative recommendations by Google. 