### PR TITLE
fix: use RECEIVER_NOT_EXPORTED on SDK 33 and up

### DIFF
--- a/uploadservice/src/main/java/net/gotev/uploadservice/extensions/ContextExtensions.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/extensions/ContextExtensions.kt
@@ -238,7 +238,7 @@ inline fun <reified T : Parcelable> Intent.parcelableCompat(key: String): T? = w
 
 @SuppressLint("UnspecifiedRegisterReceiverFlag")
 fun Context.registerReceiverCompat(receiver: BroadcastReceiver, filter: IntentFilter) {
-    if (SDK_INT >= 34) {
+    if (SDK_INT >= 33) {
         registerReceiver(receiver, filter, RECEIVER_NOT_EXPORTED)
     } else {
         registerReceiver(receiver, filter)


### PR DESCRIPTION
This API was introduced in SDK 33, but wasn't required until you targeted SDK 34. Once you target SDK 34, running the app on a 33 device will trigger an error stating this is required.